### PR TITLE
Fixed Faraday::Connection#token_auth, Faraday 2.0 - deprecated warning.

### DIFF
--- a/lib/zammad_api/transport.rb
+++ b/lib/zammad_api/transport.rb
@@ -20,7 +20,7 @@ module ZammadAPI
       elsif config[:oauth2_token] && !config[:oauth2_token].empty?
         @conn.request :authorization, 'Bearer', config[:oauth2_token]
       else
-        @conn.request :authorization, :basic, config[:user], config[:password]
+        @conn.request :basic_auth, config[:user], config[:password]
       end
     end
 

--- a/lib/zammad_api/transport.rb
+++ b/lib/zammad_api/transport.rb
@@ -16,11 +16,11 @@ module ZammadAPI
       end
       @conn.headers[:user_agent] = 'Zammad API Ruby'
       if config[:http_token] && !config[:http_token].empty?
-        @conn.token_auth(config[:http_token])
+        @conn.request :authorization, 'Token', config[:http_token]
       elsif config[:oauth2_token] && !config[:oauth2_token].empty?
-        @conn.authorization :Bearer, config[:oauth2_token]
+        @conn.request :authorization, 'Bearer', config[:oauth2_token]
       else
-        @conn.basic_auth(config[:user], config[:password])
+        @conn.request :authorization, :basic, config[:user], config[:password]
       end
     end
 


### PR DESCRIPTION
Wenn I use the Zammad API Client with Faraday 1.9, I get the deprecated warning below. This PR is solving it.

With basic auth:

```
WARNING: `Faraday::Connection#basic_auth` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:basic_auth, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
```

with token auth:
```
WARNING: `Faraday::Connection#token_auth` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:token_auth, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
```