### PR TITLE
feat: add semantic error classes

### DIFF
--- a/lib/zammad_api.rb
+++ b/lib/zammad_api.rb
@@ -1,4 +1,5 @@
 require 'zammad_api/version'
+require 'zammad_api/errors'
 require 'zammad_api/client'
 
 module ZammadAPI

--- a/lib/zammad_api/client.rb
+++ b/lib/zammad_api/client.rb
@@ -31,7 +31,7 @@ module ZammadAPI
       begin
         class_object = Kernel.const_get(class_name)
       rescue
-        raise "Resource for #{method} does not exist"
+        raise ResourceNotFoundError, "Resource for #{method} does not exist"
       end
       ZammadAPI::Dispatcher.new(@transport, class_object)
     end
@@ -39,20 +39,20 @@ module ZammadAPI
     private
 
     def check_config
-      raise 'missing url in config' if !@config[:url]
-      raise 'config url needs to start with http:// or https://' if !%r{^(http|https)://}.match?(@config[:url])
+      raise ConfigurationError, 'missing url in config' if !@config[:url]
+      raise ConfigurationError, 'config url needs to start with http:// or https://' if !%r{^(http|https)://}.match?(@config[:url])
 
       # check for token auth
       return if @config[:http_token] && !@config[:http_token].empty?
       return if @config[:oauth2_token] && !@config[:oauth2_token].empty?
 
       if !@config[:user] || @config[:user].empty?
-        raise 'missing user in config'
+        raise ConfigurationError, 'missing user in config'
       end
 
       return if @config[:password] && !@config[:password].empty?
 
-      raise 'missing password in config'
+      raise ConfigurationError, 'missing password in config'
     end
 
     def modulize(string)

--- a/lib/zammad_api/errors.rb
+++ b/lib/zammad_api/errors.rb
@@ -1,0 +1,62 @@
+require 'json'
+
+module ZammadAPI
+  class Error < RuntimeError; end
+
+  class ConfigurationError < Error; end
+
+  class ResourceNotFoundError < Error; end
+
+  class ResponseError < Error
+    attr_reader :response, :operation, :resource_class
+
+    def initialize(operation:, response:, resource_class: nil)
+      @operation      = operation
+      @response       = response
+      @resource_class = resource_class
+      super(default_message)
+    end
+
+    def status
+      response&.status
+    end
+
+    def body
+      response&.body
+    end
+
+    def self.from(response, **kwargs)
+      klass = if response.nil?
+                self
+              elsif response.status >= 500
+                ServerError
+              else
+                ClientError
+              end
+      klass.new(response: response, **kwargs)
+    end
+
+    private
+
+    def default_message
+      subject = resource_class ? "#{operation} (#{resource_class.name})" : operation
+      "Can't #{subject}: #{detail}"
+    end
+
+    def detail
+      body_error || "HTTP #{status}"
+    end
+
+    def body_error
+      return nil if body.to_s.strip.empty?
+
+      parsed = JSON.parse(body)
+      parsed.is_a?(Hash) ? parsed['error'] : nil
+    rescue JSON::ParserError
+      nil
+    end
+  end
+
+  class ClientError < ResponseError; end
+  class ServerError < ResponseError; end
+end

--- a/lib/zammad_api/list_base.rb
+++ b/lib/zammad_api/list_base.rb
@@ -62,10 +62,11 @@ module ZammadAPI
       }.join('&')
 
       response = @transport.get(url: url)
-      data = safe_json_parse(response.body)
       if response.status != 200
-        raise "Can't get .#{request} of object (#{@resource.class.name}): #{data['error']}"
+        raise ResponseError.from(response, operation: "get .#{request} of object", resource_class: @resource.class)
       end
+
+      data = safe_json_parse(response.body)
 
       list = []
       data.each do |local_data|
@@ -77,7 +78,7 @@ module ZammadAPI
     end
 
     def perform_request(_parameter)
-      raise "no perform_request implementation for #{self.class.name} found"
+      raise Error, "no perform_request implementation for #{self.class.name} found"
     end
   end
 end

--- a/lib/zammad_api/resources/base.rb
+++ b/lib/zammad_api/resources/base.rb
@@ -43,12 +43,9 @@ module ZammadAPI
 
       def destroy
         response = @transport.delete(url: "#{@url}/#{@attributes[:id]}")
-        if response.body.to_s != '' && response.body.to_s != ' '
-          data = safe_json_parse(response.body)
-        end
         return true if response.status == 200
 
-        raise "Can't destroy object (#{self.class.name}): #{data['error']}"
+        raise ResponseError.from(response, operation: 'destroy object', resource_class: self.class)
       end
 
       def save
@@ -79,11 +76,11 @@ module ZammadAPI
 
       def self.find(transport, id)
         response = transport.get(url: "#{@url}/#{id}?expand=true")
-        data = safe_json_parse(response.body)
         if response.status != 200
-          raise "Can't find object (#{self.class.name}): #{data['error']}"
+          raise ResponseError.from(response, operation: 'find object', resource_class: self)
         end
 
+        data = safe_json_parse(response.body)
         item = new(transport, data)
         item.new_instance = false
         item
@@ -114,7 +111,7 @@ module ZammadAPI
         attributes = safe_json_parse(response.body)
         return attributes if response.status == 201
 
-        save_error(attributes)
+        save_error(response)
       end
 
       def save_existing
@@ -127,11 +124,11 @@ module ZammadAPI
 
         return attributes if response.status == 200
 
-        save_error(attributes)
+        save_error(response)
       end
 
-      def save_error(attributes)
-        raise "Can't save object (#{self.class.name}): #{attributes['error']}"
+      def save_error(response)
+        raise ResponseError.from(response, operation: 'save object', resource_class: self.class)
       end
 
       def symbolize_keys_deep!(hash)

--- a/lib/zammad_api/resources/base.rb
+++ b/lib/zammad_api/resources/base.rb
@@ -107,9 +107,8 @@ module ZammadAPI
       end
 
       def save_new
-        response   = @transport.post(url: "#{@url}?expand=true", params: @attributes)
-        attributes = safe_json_parse(response.body)
-        return attributes if response.status == 201
+        response = @transport.post(url: "#{@url}?expand=true", params: @attributes)
+        return safe_json_parse(response.body) if response.status == 201
 
         save_error(response)
       end
@@ -119,10 +118,8 @@ module ZammadAPI
         @changes.each do |name, values|
           attributes_to_post[name] = values[1]
         end
-        response   = @transport.put(url: "#{@url}/#{@attributes[:id]}?expand=true", params: attributes_to_post)
-        attributes = safe_json_parse(response.body)
-
-        return attributes if response.status == 200
+        response = @transport.put(url: "#{@url}/#{@attributes[:id]}?expand=true", params: attributes_to_post)
+        return safe_json_parse(response.body) if response.status == 200
 
         save_error(response)
       end

--- a/lib/zammad_api/resources/ticket.rb
+++ b/lib/zammad_api/resources/ticket.rb
@@ -3,10 +3,11 @@ class ZammadAPI::Resources::Ticket < ZammadAPI::Resources::Base
 
   def articles
     response = @transport.get(url: "/api/v1/ticket_articles/by_ticket/#{id}?expand=true")
-    data = safe_json_parse(response.body)
     if response.status != 200
-      raise "Can't get articles (#{self.class.name}): #{data['error']}"
+      raise ZammadAPI::ResponseError.from(response, operation: 'get articles', resource_class: self.class)
     end
+
+    data = safe_json_parse(response.body)
 
     data.collect do |raw|
       item = ZammadAPI::Resources::TicketArticle.new(@transport, raw)

--- a/lib/zammad_api/resources/ticket_article_attachment.rb
+++ b/lib/zammad_api/resources/ticket_article_attachment.rb
@@ -13,7 +13,6 @@ class ZammadAPI::Resources::TicketArticleAttachment < ZammadAPI::Resources::Base
     response = @transport.get(url: "/api/v1/ticket_attachment/#{ticket_id}/#{article_id}/#{id}")
     return response.body if response.status == 200
 
-    data = safe_json_parse(response.body)
-    raise "Can't get articles (#{self.class.name}): #{data['error']}"
+    raise ZammadAPI::ResponseError.from(response, operation: 'get articles', resource_class: self.class)
   end
 end

--- a/spec/zammad_api/client_spec.rb
+++ b/spec/zammad_api/client_spec.rb
@@ -17,6 +17,48 @@ describe ZammadAPI::Client do
   let(:config) { Helper.config }
   let(:instance) { described_class.new(config) }
 
+  describe '.new' do
+    it 'raises ConfigurationError when url is missing' do
+      expect { described_class.new(config.merge(url: nil)) }
+        .to raise_error(ZammadAPI::ConfigurationError, 'missing url in config')
+    end
+
+    it 'raises ConfigurationError when url scheme is unsupported' do
+      expect { described_class.new(config.merge(url: 'ftp://example.com')) }
+        .to raise_error(ZammadAPI::ConfigurationError, 'config url needs to start with http:// or https://')
+    end
+
+    it 'raises ConfigurationError when user is missing' do
+      expect { described_class.new(config.merge(user: nil)) }
+        .to raise_error(ZammadAPI::ConfigurationError, 'missing user in config')
+    end
+
+    it 'raises ConfigurationError when password is missing' do
+      expect { described_class.new(config.merge(password: nil)) }
+        .to raise_error(ZammadAPI::ConfigurationError, 'missing password in config')
+    end
+
+    it 'does not require user/password when http_token is supplied' do
+      expect { described_class.new(url: config[:url], http_token: 'token') }.not_to raise_error
+    end
+
+    it 'does not require user/password when oauth2_token is supplied' do
+      expect { described_class.new(url: config[:url], oauth2_token: 'token') }.not_to raise_error
+    end
+  end
+
+  describe '#method_missing' do
+    it 'raises ResourceNotFoundError for unknown resources' do
+      expect { instance.does_not_exist }.to raise_error(ZammadAPI::ResourceNotFoundError, /Resource for DoesNotExist does not exist/)
+    end
+
+    it 'attaches the underlying NameError as #cause' do
+      instance.does_not_exist
+    rescue ZammadAPI::ResourceNotFoundError => e
+      expect(e.cause).to be_a(NameError)
+    end
+  end
+
   describe '#perform_on_behalf_of' do
     it 'performs a given block on behalft of a given user' do
       on_behalf_of_identifier = 'some_login'

--- a/spec/zammad_api/errors_spec.rb
+++ b/spec/zammad_api/errors_spec.rb
@@ -1,0 +1,164 @@
+require 'spec_helper'
+
+describe ZammadAPI do
+  describe ZammadAPI::Error do
+    it 'descends from RuntimeError' do
+      expect(described_class.ancestors).to include(RuntimeError)
+    end
+  end
+
+  describe ZammadAPI::ConfigurationError do
+    it 'descends from ZammadAPI::Error' do
+      expect(described_class.ancestors).to include(ZammadAPI::Error)
+    end
+
+    it 'descends from RuntimeError' do
+      expect(described_class.ancestors).to include(RuntimeError)
+    end
+  end
+
+  describe ZammadAPI::ResourceNotFoundError do
+    it 'descends from ZammadAPI::Error' do
+      expect(described_class.ancestors).to include(ZammadAPI::Error)
+    end
+
+    it 'descends from RuntimeError' do
+      expect(described_class.ancestors).to include(RuntimeError)
+    end
+  end
+
+  describe ZammadAPI::ResponseError do
+    let(:fake_response) { Struct.new(:status, :body) }
+
+    describe '.from' do
+      it 'returns a ClientError for 4xx responses' do
+        response = fake_response.new(404, '{}')
+        expect(described_class.from(response, operation: 'find object')).to be_a(ZammadAPI::ClientError)
+      end
+
+      it 'returns a ClientError for 408 (Request Timeout)' do
+        response = fake_response.new(408, '{}')
+        expect(described_class.from(response, operation: 'find object')).to be_a(ZammadAPI::ClientError)
+      end
+
+      it 'returns a ClientError for 429 (Too Many Requests)' do
+        response = fake_response.new(429, '{}')
+        expect(described_class.from(response, operation: 'find object')).to be_a(ZammadAPI::ClientError)
+      end
+
+      it 'returns a ServerError for 5xx responses' do
+        response = fake_response.new(500, '{}')
+        expect(described_class.from(response, operation: 'find object')).to be_a(ZammadAPI::ServerError)
+      end
+
+      it 'returns a ServerError for 502 (Bad Gateway)' do
+        response = fake_response.new(502, '<html>Bad Gateway</html>')
+        expect(described_class.from(response, operation: 'find object')).to be_a(ZammadAPI::ServerError)
+      end
+
+      it 'returns a base ResponseError when no response is supplied' do
+        result = described_class.from(nil, operation: 'find object')
+        expect(result.class).to eq(described_class)
+      end
+    end
+
+    describe 'subclasses' do
+      it 'ClientError descends from ResponseError' do
+        expect(ZammadAPI::ClientError.ancestors).to include(described_class)
+      end
+
+      it 'ServerError descends from ResponseError' do
+        expect(ZammadAPI::ServerError.ancestors).to include(described_class)
+      end
+
+      it 'descends from ZammadAPI::Error' do
+        expect(described_class.ancestors).to include(ZammadAPI::Error)
+      end
+
+      it 'descends from RuntimeError' do
+        expect(described_class.ancestors).to include(RuntimeError)
+      end
+    end
+
+    describe '#message' do
+      it "uses the JSON body's 'error' key when present" do
+        response = fake_response.new(404, '{"error":"User not found"}')
+        error = described_class.from(response, operation: 'find object', resource_class: ZammadAPI::Resources::User)
+        expect(error.message).to eq("Can't find object (ZammadAPI::Resources::User): User not found")
+      end
+
+      it 'preserves the original message format for the JSON-with-error case' do
+        response = fake_response.new(422, '{"error":"name can\'t be blank"}')
+        error = described_class.from(response, operation: 'save object', resource_class: ZammadAPI::Resources::Group)
+        expect(error.message).to eq("Can't save object (ZammadAPI::Resources::Group): name can't be blank")
+      end
+
+      it 'falls back to HTTP status when the body is not JSON (issue #29 scenario)' do
+        response = fake_response.new(502, '<html><body>Bad Gateway</body></html>')
+        error = described_class.from(response, operation: 'find object', resource_class: ZammadAPI::Resources::User)
+        expect(error.message).to eq("Can't find object (ZammadAPI::Resources::User): HTTP 502")
+      end
+
+      it 'falls back to HTTP status when the body is empty' do
+        response = fake_response.new(500, '')
+        error = described_class.from(response, operation: 'destroy object', resource_class: ZammadAPI::Resources::User)
+        expect(error.message).to eq("Can't destroy object (ZammadAPI::Resources::User): HTTP 500")
+      end
+
+      it "falls back to HTTP status when the JSON body has no 'error' key" do
+        response = fake_response.new(400, '{"foo":"bar"}')
+        error = described_class.from(response, operation: 'find object', resource_class: ZammadAPI::Resources::User)
+        expect(error.message).to eq("Can't find object (ZammadAPI::Resources::User): HTTP 400")
+      end
+
+      it 'omits the resource_class segment when none is supplied' do
+        response = fake_response.new(404, '{"error":"nope"}')
+        error = described_class.from(response, operation: 'find object')
+        expect(error.message).to eq("Can't find object: nope")
+      end
+
+      it 'does not attach the JSON parser error as cause (it is a symptom, not the cause)' do
+        response = fake_response.new(502, '<html>Bad Gateway</html>')
+        error = described_class.from(response, operation: 'find object')
+        expect(error.cause).to be_nil
+      end
+    end
+
+    describe 'accessors' do
+      let(:response) { fake_response.new(404, '{"error":"nope"}') }
+      let(:error) do
+        described_class.from(response, operation: 'find object', resource_class: ZammadAPI::Resources::User)
+      end
+
+      it 'exposes the underlying response' do
+        expect(error.response).to be(response)
+      end
+
+      it 'exposes the response status' do
+        expect(error.status).to eq(404)
+      end
+
+      it 'exposes the response body' do
+        expect(error.body).to eq('{"error":"nope"}')
+      end
+
+      it 'exposes the operation' do
+        expect(error.operation).to eq('find object')
+      end
+
+      it 'exposes the resource_class' do
+        expect(error.resource_class).to eq(ZammadAPI::Resources::User)
+      end
+
+      it 'returns nil for status when no response is supplied' do
+        error = described_class.from(nil, operation: 'find object')
+        expect(error.status).to be_nil
+      end
+
+      it 'returns nil for body when no response is supplied' do
+        error = described_class.from(nil, operation: 'find object')
+        expect(error.body).to be_nil
+      end
+    end
+  end
+end

--- a/spec/zammad_api/resources/group_spec.rb
+++ b/spec/zammad_api/resources/group_spec.rb
@@ -12,7 +12,7 @@ describe ZammadAPI, 'group object basics' do
     expect(group_invalid.class).to eq(ZammadAPI::Resources::Group)
     expect(group_invalid.new_record?).to be(true)
 
-    expect { group_invalid.save }.to raise_error(RuntimeError)
+    expect { group_invalid.save }.to raise_error(ZammadAPI::ClientError)
   end
 
   it 'new with valid attributes' do

--- a/spec/zammad_api/resources/organization_spec.rb
+++ b/spec/zammad_api/resources/organization_spec.rb
@@ -12,7 +12,7 @@ describe ZammadAPI, 'organization object basics' do
     expect(organization_invalid.class).to eq(ZammadAPI::Resources::Organization)
     expect(organization_invalid.new_record?).to be(true)
 
-    expect { organization_invalid.save }.to raise_error(RuntimeError)
+    expect { organization_invalid.save }.to raise_error(ZammadAPI::ClientError)
   end
 
   it 'new with valid attributes' do

--- a/spec/zammad_api/resources/ticket_priority_spec.rb
+++ b/spec/zammad_api/resources/ticket_priority_spec.rb
@@ -12,7 +12,7 @@ describe ZammadAPI, 'ticket priority object basics' do
     expect(ticket_priority_invalid.class).to eq(ZammadAPI::Resources::TicketPriority)
     expect(ticket_priority_invalid.new_record?).to be(true)
 
-    expect { ticket_priority_invalid.save }.to raise_error(RuntimeError)
+    expect { ticket_priority_invalid.save }.to raise_error(ZammadAPI::ClientError)
   end
 
   it 'new with valid attributes' do

--- a/spec/zammad_api/resources/ticket_spec.rb
+++ b/spec/zammad_api/resources/ticket_spec.rb
@@ -12,7 +12,7 @@ describe ZammadAPI, 'ticket object basics' do
     expect(ticket_invalid.class).to eq(ZammadAPI::Resources::Ticket)
     expect(ticket_invalid.new_record?).to be(true)
 
-    expect { ticket_invalid.save }.to raise_error(RuntimeError)
+    expect { ticket_invalid.save }.to raise_error(ZammadAPI::ClientError)
   end
 
   it 'new with valid attributes' do

--- a/spec/zammad_api/resources/ticket_state_spec.rb
+++ b/spec/zammad_api/resources/ticket_state_spec.rb
@@ -12,7 +12,7 @@ describe ZammadAPI, 'ticket state object basics' do
     expect(ticket_state_invalid.class).to eq(ZammadAPI::Resources::TicketState)
     expect(ticket_state_invalid.new_record?).to be(true)
 
-    expect { ticket_state_invalid.save }.to raise_error(RuntimeError)
+    expect { ticket_state_invalid.save }.to raise_error(ZammadAPI::ClientError)
   end
 
   it 'new with valid attributes' do

--- a/spec/zammad_api/resources/user_spec.rb
+++ b/spec/zammad_api/resources/user_spec.rb
@@ -15,7 +15,7 @@ describe ZammadAPI, 'user object basics' do
     expect(user_invalid.class).to eq(ZammadAPI::Resources::User)
     expect(user_invalid.new_record?).to be(true)
 
-    expect { user_invalid.save }.to raise_error(RuntimeError)
+    expect { user_invalid.save }.to raise_error(ZammadAPI::ClientError)
   end
 
   it 'new with valid attributes' do
@@ -268,7 +268,7 @@ describe ZammadAPI, 'user object basics' do
     # to have some references and not allow users to delete
     sleep 12
 
-    expect { user.destroy }.to raise_error(RuntimeError)
+    expect { user.destroy }.to raise_error(ZammadAPI::ClientError)
     #result = user.destroy
     #expect(result).to eq(true)
   end

--- a/spec/zammad_api_spec.rb
+++ b/spec/zammad_api_spec.rb
@@ -10,23 +10,27 @@ describe ZammadAPI do
     client = Helper.client(user: 'not_existing', password: 'not_existing')
 
     it 'user' do
-      expect { client.user.find(1) }.to raise_error(RuntimeError)
+      expect { client.user.find(1) }.to raise_error(ZammadAPI::ClientError) do |error|
+        expect(error.status).to eq(401)
+        expect(error.operation).to eq('find object')
+        expect(error.resource_class).to eq(ZammadAPI::Resources::User)
+      end
     end
 
     it 'organization' do
-      expect { client.organization.find(1) }.to raise_error(RuntimeError)
+      expect { client.organization.find(1) }.to raise_error(ZammadAPI::ClientError)
     end
 
     it 'group' do
-      expect { client.group.find(1) }.to raise_error(RuntimeError)
+      expect { client.group.find(1) }.to raise_error(ZammadAPI::ClientError)
     end
 
     it 'ticket_priority' do
-      expect { client.ticket_priority.find(1) }.to raise_error(RuntimeError)
+      expect { client.ticket_priority.find(1) }.to raise_error(ZammadAPI::ClientError)
     end
 
     it 'ticket_state' do
-      expect { client.ticket_state.find(1) }.to raise_error(RuntimeError)
+      expect { client.ticket_state.find(1) }.to raise_error(ZammadAPI::ClientError)
     end
   end
 end


### PR DESCRIPTION
Hello, this is a follow-up to #29 and its speedy fix in c3af2a9cac939e79731c80dca9b710a861ac79e0.

While that fix removed the `JSON::ParserError`, it led to a context-less `RuntimeError` without sufficient information to programmatically discern error reasons. This affects our usage because we do things such as create tickets in background jobs and knowing when to retry (e.g. a 5xx error) vs give up and log an exception more visibly is important.

This PR includes commits to introduce new semantic/contextful exceptions to the failure paths, taking care to:

- Remain backwards compatible (still `RuntimeError`, same `#message`, etc)
- Minimise lines of code changed in existing paths
- Provide an interface on new exceptions for callers to sufficiently discern the errors
- Improve the error message where JSON is unparseable

This PR does **not** tackle reverting the recent introduction of `safe_json_parse` because that _could_ be considered a breaking change, though I am in favour of doing so because its remaining usages are only in the success paths, which could lead to a scenario where a 2xx response which somehow included corrupt JSON would not be detectable. In that case, a `JSON::ParserError` _does_ feel appropriate. Nonetheless, I'll leave the decision to include that change to the maintainers.

This PR is best reviewed commit-by-commit. The first commit introduces the new error classes but _preserves_ all existing specs in an effort to demonstrate backwards compatibility. The second commit changes the specs and introduces tests for the error classes themselves, to support ongoing regression prevention for existing code which may match on the contents of `RuntimeError#message`.

I hope this code can be merged quickly and I'm more than happy to make revisions as you see fit to get it to an acceptable state.