### PR TITLE
Fixes #21 - Use 'From' instead of 'X-On-Behalf-Of'

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,9 @@ groups.page(2,3) {|group|
 
 ## Perform actions on behalf of another user
 
-As described in the [Zammad API documentation](https://docs.zammad.org/en/latest/api-intro.html#example-curl-request-on-behalf-of-a-different-user) it is possible to perfom actions on behalf other users. To use this feature you can set the attribute of the client accordingly:
+As described in the [Zammad API documentation](https://docs.zammad.org/en/latest/api/intro.html#actions-on-behalf-of-other-users) it is possible to perfom actions on behalf other users. To use this feature you can set the attribute of the client accordingly:
+
+> **Note:** This feature requires Zammad 5.0 or later, since the client sends the standard HTTP `From` header instead of the deprecated `X-On-Behalf-Of` header (see [zammad/zammad#3113](https://github.com/zammad/zammad/issues/3113)).
 
 ```ruby
 client.on_behalf_of = 'some_login'

--- a/lib/zammad_api/transport.rb
+++ b/lib/zammad_api/transport.rb
@@ -50,7 +50,7 @@ module ZammadAPI
         end
 
         if !on_behalf_of.nil?
-          req.headers['X-On-Behalf-Of'] = on_behalf_of
+          req.headers['From'] = on_behalf_of
         end
 
         yield(req) if block_given?

--- a/spec/zammad_api/client_spec.rb
+++ b/spec/zammad_api/client_spec.rb
@@ -65,7 +65,7 @@ describe ZammadAPI::Client do
 
       stub_request(:get, /#{config[:url]}/)
         .with(headers: {
-                'X-On-Behalf-Of' => on_behalf_of_identifier
+                'From' => on_behalf_of_identifier
               })
         .to_return(status: 200, body: '{}', headers: {})
 
@@ -80,7 +80,7 @@ describe ZammadAPI::Client do
 
       stub_request(:get, /#{config[:url]}/)
         .with(headers: {
-                'X-On-Behalf-Of' => on_behalf_of_identifier
+                'From' => on_behalf_of_identifier
               })
         .to_return(status: 200, body: '{}', headers: {})
 
@@ -101,7 +101,7 @@ describe ZammadAPI::Client do
         return false if !super
         return true if request_signature.headers.empty?
 
-        !request_signature.headers.key?('X-On-Behalf-Of')
+        !request_signature.headers.key?('From')
       end
 
       instance.user.find(1)

--- a/spec/zammad_api/transport_spec.rb
+++ b/spec/zammad_api/transport_spec.rb
@@ -40,21 +40,21 @@ describe ZammadAPI::Transport do
       expect(instance).to respond_to(:on_behalf_of=)
     end
 
-    it 'sets X-On-Behalf-Of header' do
+    it 'sets From header' do
       on_behalf_of_identifier = 'some_login'
 
       instance.on_behalf_of = on_behalf_of_identifier
 
       stub_request(:get, "#{config[:url]}some/path")
         .with(headers: {
-                'X-On-Behalf-Of' => on_behalf_of_identifier
+                'From' => on_behalf_of_identifier
               })
         .to_return(status: 200, body: '', headers: {})
 
       instance.get(url: '/some/path')
     end
 
-    it 'unsets X-On-Behalf-Of header' do
+    it 'unsets From header' do
       on_behalf_of_identifier = 'some_login'
 
       instance.on_behalf_of = on_behalf_of_identifier
@@ -71,7 +71,7 @@ describe ZammadAPI::Transport do
         return false if !super
         return true if request_signature.headers.empty?
 
-        !request_signature.headers.key?('X-On-Behalf-Of')
+        !request_signature.headers.key?('From')
       end
 
       instance.get(url: '/some/path')


### PR DESCRIPTION
The 'X-On-Behalf-Of' header was deprecated in favor of the standard HTTP 'From' header (see zammad/zammad#5541). Update the transport to send 'From' and adjust specs and README accordingly.